### PR TITLE
feat(import): replace CSV parser with Excel bulk upload

### DIFF
--- a/src/app/components/import/import-dialog.ts
+++ b/src/app/components/import/import-dialog.ts
@@ -5,9 +5,9 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ImportService } from '../../services/import.service';
-import { ImportRow, ImportPreview, ImportResult } from '../../interfaces/import.interface';
+import { ImportResult } from '../../interfaces/import.interface';
 
-type ImportStep = 'upload' | 'preview' | 'importing' | 'result';
+type ImportStep = 'upload' | 'importing' | 'result';
 
 @Component({
   selector: 'app-import-dialog',
@@ -70,7 +70,7 @@ type ImportStep = 'upload' | 'preview' | 'importing' | 'result';
               <label class="inline-block">
                 <input
                   type="file"
-                  accept=".csv"
+                  accept=".xlsx"
                   class="hidden"
                   (change)="onFileSelect($event)"
                 />
@@ -92,77 +92,7 @@ type ImportStep = 'upload' | 'preview' | 'importing' | 'result';
           </div>
         }
 
-        <!-- Step 2: Preview -->
-        @if (step() === 'preview' && preview()) {
-          <div class="space-y-4">
-            <!-- Summary -->
-            <div class="grid grid-cols-3 gap-4">
-              <div class="bg-[var(--color-surface)] rounded-lg p-4 text-center">
-                <p class="text-2xl font-bold text-foreground">{{ preview()!.totalCount }}</p>
-                <p class="text-sm text-[var(--color-on-surface-variant)]">{{ 'IMPORT.TOTAL_ROWS' | translate }}</p>
-              </div>
-              <div class="bg-[var(--color-surface)] rounded-lg p-4 text-center">
-                <p class="text-2xl font-bold text-[var(--color-status-success)]">{{ preview()!.validCount }}</p>
-                <p class="text-sm text-[var(--color-on-surface-variant)]">{{ 'IMPORT.VALID_ROWS' | translate }}</p>
-              </div>
-              <div class="bg-[var(--color-surface)] rounded-lg p-4 text-center">
-                <p class="text-2xl font-bold text-[var(--color-status-error)]">{{ preview()!.invalidCount }}</p>
-                <p class="text-sm text-[var(--color-on-surface-variant)]">{{ 'IMPORT.INVALID_ROWS' | translate }}</p>
-              </div>
-            </div>
-
-            <!-- Preview Table -->
-            <div class="bg-[var(--color-surface)] rounded-lg overflow-hidden">
-              <div class="max-h-[300px] overflow-auto">
-                <table class="w-full text-sm">
-                  <thead class="sticky top-0 bg-[var(--color-surface-variant)]">
-                    <tr>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">#</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_STATUS' | translate }}</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_NAME' | translate }}</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_CATEGORY' | translate }}</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_QTY' | translate }}</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_WAREHOUSE' | translate }}</th>
-                      <th class="text-left px-4 py-3 text-[var(--color-on-surface-variant)] font-medium">{{ 'IMPORT.COL_ERRORS' | translate }}</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-[var(--color-border-subtle)]">
-                    @for (row of preview()!.rows; track row.rowNumber) {
-                      <tr [class]="row.isValid ? '' : 'bg-[var(--color-error-bg)]'">
-                        <td class="px-4 py-3 text-[var(--color-on-surface-variant)]">{{ row.rowNumber }}</td>
-                        <td class="px-4 py-3">
-                          @if (row.isValid) {
-                            <span class="text-[var(--color-status-success)]"><lucide-icon name="CheckCircle2" class="!w-4 !h-4"></lucide-icon></span>
-                          } @else {
-                            <span class="text-[var(--color-status-error)]"><lucide-icon name="AlertCircle" class="!w-4 !h-4"></lucide-icon></span>
-                          }
-                        </td>
-                        <td class="px-4 py-3 text-foreground">{{ row.name || '-' }}</td>
-                        <td class="px-4 py-3 text-[var(--color-on-surface-variant)]">{{ row.category || '-' }}</td>
-                        <td class="px-4 py-3 text-[var(--color-on-surface-variant)]">{{ row.quantity }}</td>
-                        <td class="px-4 py-3 text-[var(--color-on-surface-variant)]">{{ row.warehouseName || '-' }}</td>
-                        <td class="px-4 py-3 text-[var(--color-status-error)] text-xs">
-                          {{ row.errors.join(', ') }}
-                        </td>
-                      </tr>
-                    }
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-            @if (preview()!.invalidCount > 0) {
-              <div class="bg-[var(--color-accent-amber-bg)] border border-[var(--color-warning-border)] rounded-lg p-4">
-                <div class="flex items-start gap-2 text-amber-400">
-                  <lucide-icon name="AlertTriangle" class="mt-0.5 !w-5 !h-5"></lucide-icon>
-                  <p class="text-sm">{{ 'IMPORT.INVALID_WARNING' | translate }}</p>
-                </div>
-              </div>
-            }
-          </div>
-        }
-
-        <!-- Step 3: Importing -->
+        <!-- Step 2: Importing -->
         @if (step() === 'importing') {
           <div class="text-center py-8">
             <lucide-icon name="CloudCog" class="!w-12 !h-12 text-[var(--color-primary)] mb-4 animate-pulse"></lucide-icon>
@@ -176,7 +106,7 @@ type ImportStep = 'upload' | 'preview' | 'importing' | 'result';
           </div>
         }
 
-        <!-- Step 4: Result -->
+        <!-- Step 3: Result -->
         @if (step() === 'result' && result()) {
           <div class="space-y-6">
             <!-- Success/Error Icon -->
@@ -222,39 +152,19 @@ type ImportStep = 'upload' | 'preview' | 'importing' | 'result';
       </div>
 
       <!-- Footer -->
-      <div class="flex justify-between items-center gap-3 px-6 py-4 border-t border-[var(--color-border-subtle)]">
-        <div>
-          @if (step() === 'preview') {
-            <button
-              (click)="goBack()"
-              class="px-4 py-2 text-[var(--color-on-surface-variant)] hover:text-foreground transition-colors">
-              <lucide-icon name="ArrowLeft" class="!w-4 !h-4 align-middle mr-1"></lucide-icon>
-              {{ 'COMMON.BACK' | translate }}
-            </button>
-          }
-        </div>
-        <div class="flex gap-3">
+      <div class="flex justify-end items-center gap-3 px-6 py-4 border-t border-[var(--color-border-subtle)]">
+        <button
+          (click)="dialogRef.close()"
+          class="px-6 py-2.5 rounded-lg bg-[var(--color-surface-elevated)] text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-elevated)] hover:text-foreground transition-colors font-medium">
+          {{ step() === 'result' ? ('COMMON.CLOSE' | translate) : ('COMMON.CANCEL' | translate) }}
+        </button>
+        @if (step() === 'result') {
           <button
-            (click)="dialogRef.close()"
-            class="px-6 py-2.5 rounded-lg bg-[var(--color-surface-elevated)] text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-elevated)] hover:text-foreground transition-colors font-medium">
-            {{ step() === 'result' ? ('COMMON.CLOSE' | translate) : ('COMMON.CANCEL' | translate) }}
+            (click)="dialogRef.close(true)"
+            class="ds-btn ds-btn--primary">
+            {{ 'COMMON.DONE' | translate }}
           </button>
-          @if (step() === 'preview' && preview()!.validCount > 0) {
-            <button
-              (click)="startImport()"
-              class="ds-btn ds-btn--primary">
-              <lucide-icon name="Upload" class="shrink-0"></lucide-icon>
-              {{ 'IMPORT.IMPORT_VALID' | translate }} ({{ preview()!.validCount }})
-            </button>
-          }
-          @if (step() === 'result') {
-            <button
-              (click)="dialogRef.close(true)"
-              class="ds-btn ds-btn--primary">
-              {{ 'COMMON.DONE' | translate }}
-            </button>
-          }
-        </div>
+        }
       </div>
     </div>
   `,
@@ -273,7 +183,6 @@ export class ImportDialog {
   step = signal<ImportStep>('upload');
   dragOver = signal(false);
   fileError = signal<string | null>(null);
-  preview = signal<ImportPreview | null>(null);
   result = signal<ImportResult | null>(null);
 
   downloadTemplate(): void {
@@ -313,71 +222,28 @@ export class ImportDialog {
   private processFile(file: File): void {
     this.fileError.set(null);
 
-    // Validate file type (only CSV is supported)
     const extension = '.' + file.name.split('.').pop()?.toLowerCase();
-    if (extension !== '.csv') {
-      this.fileError.set('Invalid file type. Please upload a CSV file.');
+    if (extension !== '.xlsx') {
+      this.fileError.set('Formato inválido. Por favor sube un archivo Excel (.xlsx).');
       return;
     }
-
-    // Read file
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const content = e.target?.result as string;
-      this.parseAndPreview(content);
-    };
-    reader.onerror = () => {
-      this.fileError.set('Error reading file. Please try again.');
-    };
-    reader.readAsText(file);
-  }
-
-  private parseAndPreview(content: string): void {
-    let preview = this.importService.parseCSV(content);
-
-    if (preview.totalCount === 0) {
-      this.fileError.set('No valid rows found in the file.');
-      return;
-    }
-
-    // Validate against existing data
-    preview = {
-      ...preview,
-      rows: this.importService.validateAgainstData(preview.rows),
-      validCount: 0,
-      invalidCount: 0
-    };
-    preview.validCount = preview.rows.filter(r => r.isValid).length;
-    preview.invalidCount = preview.rows.filter(r => !r.isValid).length;
-
-    this.preview.set(preview);
-    this.step.set('preview');
-  }
-
-  goBack(): void {
-    this.step.set('upload');
-    this.preview.set(null);
-  }
-
-  startImport(): void {
-    const previewData = this.preview();
-    if (!previewData) return;
 
     this.step.set('importing');
 
-    this.importService.importRows(previewData.rows).subscribe({
+    this.importService.uploadExcel(file).subscribe({
       next: (result) => {
         this.result.set(result);
         this.step.set('result');
       },
       error: (err) => {
+        const message = err?.error?.message || err?.message || 'Error al importar el archivo.';
         this.result.set({
           success: false,
-          totalRows: previewData.totalCount,
-          validRows: previewData.validCount,
-          invalidRows: previewData.invalidCount,
+          totalRows: 0,
+          validRows: 0,
+          invalidRows: 0,
           importedCount: 0,
-          errors: [{ row: 0, field: '', message: err.message || 'Import failed' }]
+          errors: [{ row: 0, field: '', message }]
         });
         this.step.set('result');
       }

--- a/src/app/components/import/import-dialog.ts
+++ b/src/app/components/import/import-dialog.ts
@@ -1,13 +1,17 @@
-import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { LucideAngularModule } from 'lucide-angular';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { ImportService } from '../../services/import.service';
 import { ImportResult } from '../../interfaces/import.interface';
 
 type ImportStep = 'upload' | 'importing' | 'result';
+
+const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 @Component({
   selector: 'app-import-dialog',
@@ -97,12 +101,7 @@ type ImportStep = 'upload' | 'importing' | 'result';
           <div class="text-center py-8">
             <lucide-icon name="CloudCog" class="!w-12 !h-12 text-[var(--color-primary)] mb-4 animate-pulse"></lucide-icon>
             <p class="text-foreground text-lg mb-4">{{ 'IMPORT.IMPORTING' | translate }}</p>
-            <mat-progress-bar
-              mode="determinate"
-              [value]="importService.progress()"
-              class="rounded-full">
-            </mat-progress-bar>
-            <p class="text-[var(--color-on-surface-variant)] text-sm mt-2">{{ importService.progress() }}%</p>
+            <mat-progress-bar mode="indeterminate" class="rounded-full"></mat-progress-bar>
           </div>
         }
 
@@ -160,6 +159,11 @@ type ImportStep = 'upload' | 'importing' | 'result';
         </button>
         @if (step() === 'result') {
           <button
+            (click)="resetToUpload()"
+            class="px-6 py-2.5 rounded-lg bg-[var(--color-surface-elevated)] text-[var(--color-on-surface-variant)] hover:bg-[var(--color-surface-elevated)] hover:text-foreground transition-colors font-medium">
+            {{ 'IMPORT.TRY_AGAIN' | translate }}
+          </button>
+          <button
             (click)="dialogRef.close(true)"
             class="ds-btn ds-btn--primary">
             {{ 'COMMON.DONE' | translate }}
@@ -177,8 +181,10 @@ type ImportStep = 'upload' | 'importing' | 'result';
   `]
 })
 export class ImportDialog {
-  dialogRef = inject(MatDialogRef<ImportDialog>);
-  importService = inject(ImportService);
+  protected dialogRef = inject(MatDialogRef<ImportDialog>);
+  protected importService = inject(ImportService);
+  private destroyRef = inject(DestroyRef);
+  private translate = inject(TranslateService);
 
   step = signal<ImportStep>('upload');
   dragOver = signal(false);
@@ -186,7 +192,9 @@ export class ImportDialog {
   result = signal<ImportResult | null>(null);
 
   downloadTemplate(): void {
-    this.importService.downloadTemplate();
+    this.importService.downloadTemplate()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
   }
 
   onDragOver(event: DragEvent): void {
@@ -198,7 +206,10 @@ export class ImportDialog {
   onDragLeave(event: DragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    this.dragOver.set(false);
+    const target = event.currentTarget as HTMLElement;
+    if (!event.relatedTarget || !target.contains(event.relatedTarget as Node)) {
+      this.dragOver.set(false);
+    }
   }
 
   onDrop(event: DragEvent): void {
@@ -219,34 +230,48 @@ export class ImportDialog {
     }
   }
 
+  resetToUpload(): void {
+    this.step.set('upload');
+    this.result.set(null);
+    this.fileError.set(null);
+  }
+
   private processFile(file: File): void {
     this.fileError.set(null);
 
     const extension = '.' + file.name.split('.').pop()?.toLowerCase();
-    if (extension !== '.xlsx') {
-      this.fileError.set('Formato inválido. Por favor sube un archivo Excel (.xlsx).');
+    if (extension !== '.xlsx' || (file.type && file.type !== XLSX_MIME)) {
+      this.fileError.set(this.translate.instant('IMPORT.INVALID_FORMAT'));
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      this.fileError.set(this.translate.instant('IMPORT.FILE_TOO_LARGE'));
       return;
     }
 
     this.step.set('importing');
 
-    this.importService.uploadExcel(file).subscribe({
-      next: (result) => {
-        this.result.set(result);
-        this.step.set('result');
-      },
-      error: (err) => {
-        const message = err?.error?.message || err?.message || 'Error al importar el archivo.';
-        this.result.set({
-          success: false,
-          totalRows: 0,
-          validRows: 0,
-          invalidRows: 0,
-          importedCount: 0,
-          errors: [{ row: 0, field: '', message }]
-        });
-        this.step.set('result');
-      }
-    });
+    this.importService.uploadExcel(file)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.result.set(result);
+          this.step.set('result');
+        },
+        error: (err) => {
+          const message = err?.error?.message || err?.message
+            || this.translate.instant('IMPORT.GENERIC_ERROR');
+          this.result.set({
+            success: false,
+            totalRows: 0,
+            validRows: 0,
+            invalidRows: 0,
+            importedCount: 0,
+            errors: [{ row: 0, field: '', message }]
+          });
+          this.step.set('result');
+        }
+      });
   }
 }

--- a/src/app/components/import/import-dialog.ts
+++ b/src/app/components/import/import-dialog.ts
@@ -140,7 +140,7 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
               <div class="bg-[var(--color-surface)] rounded-lg p-4 max-h-[200px] overflow-auto">
                 <p class="text-sm font-medium text-[var(--color-on-surface-variant)] mb-2">{{ 'IMPORT.ERROR_DETAILS' | translate }}:</p>
                 <ul class="space-y-1 text-sm text-[var(--color-status-error)]">
-                  @for (error of result()!.errors; track $index) {
+                  @for (error of result()!.errors; track error.row) {
                     <li>{{ 'IMPORT.ROW' | translate }} {{ error.row }}: {{ error.message }}</li>
                   }
                 </ul>
@@ -186,15 +186,19 @@ export class ImportDialog {
   private destroyRef = inject(DestroyRef);
   private translate = inject(TranslateService);
 
-  step = signal<ImportStep>('upload');
-  dragOver = signal(false);
-  fileError = signal<string | null>(null);
-  result = signal<ImportResult | null>(null);
+  protected step = signal<ImportStep>('upload');
+  protected dragOver = signal(false);
+  protected fileError = signal<string | null>(null);
+  protected result = signal<ImportResult | null>(null);
 
   downloadTemplate(): void {
     this.importService.downloadTemplate()
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
+      .subscribe({
+        error: () => {
+          this.fileError.set(this.translate.instant('IMPORT.GENERIC_ERROR'));
+        }
+      });
   }
 
   onDragOver(event: DragEvent): void {

--- a/src/app/components/import/import-dialog.ts
+++ b/src/app/components/import/import-dialog.ts
@@ -1,5 +1,6 @@
 import { Component, DestroyRef, inject, signal, ChangeDetectionStrategy } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { finalize } from 'rxjs/operators';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { LucideAngularModule } from 'lucide-angular';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -53,7 +54,8 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
                   <p class="text-[var(--color-on-surface-variant)] text-sm mt-1">{{ 'IMPORT.TEMPLATE_DESC' | translate }}</p>
                   <button
                     (click)="downloadTemplate()"
-                    class="mt-3 text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] text-sm font-medium flex items-center gap-1">
+                    [disabled]="downloading()"
+                    class="mt-3 text-[var(--color-primary)] hover:text-[var(--color-primary-hover)] text-sm font-medium flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed">
                     <lucide-icon name="Download" class="!w-4 !h-4"></lucide-icon>
                     {{ 'IMPORT.DOWNLOAD_TEMPLATE' | translate }}
                   </button>
@@ -182,7 +184,7 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 })
 export class ImportDialog {
   protected dialogRef = inject(MatDialogRef<ImportDialog>);
-  protected importService = inject(ImportService);
+  private importService = inject(ImportService);
   private destroyRef = inject(DestroyRef);
   private translate = inject(TranslateService);
 
@@ -190,10 +192,16 @@ export class ImportDialog {
   protected dragOver = signal(false);
   protected fileError = signal<string | null>(null);
   protected result = signal<ImportResult | null>(null);
+  protected downloading = signal(false);
 
   downloadTemplate(): void {
+    if (this.downloading()) return;
+    this.downloading.set(true);
     this.importService.downloadTemplate()
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.downloading.set(false))
+      )
       .subscribe({
         error: () => {
           this.fileError.set(this.translate.instant('IMPORT.GENERIC_ERROR'));
@@ -257,7 +265,23 @@ export class ImportDialog {
     this.step.set('importing');
 
     this.importService.uploadExcel(file)
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          // Fallback: if observable completes without emitting next or error, escape importing state
+          if (this.step() === 'importing') {
+            this.result.set({
+              success: false,
+              totalRows: 0,
+              validRows: 0,
+              invalidRows: 0,
+              importedCount: 0,
+              errors: [{ row: 0, field: '', message: this.translate.instant('IMPORT.GENERIC_ERROR') }]
+            });
+            this.step.set('result');
+          }
+        })
+      )
       .subscribe({
         next: (result) => {
           this.result.set(result);

--- a/src/app/components/import/import-dialog.ts
+++ b/src/app/components/import/import-dialog.ts
@@ -142,7 +142,7 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
               <div class="bg-[var(--color-surface)] rounded-lg p-4 max-h-[200px] overflow-auto">
                 <p class="text-sm font-medium text-[var(--color-on-surface-variant)] mb-2">{{ 'IMPORT.ERROR_DETAILS' | translate }}:</p>
                 <ul class="space-y-1 text-sm text-[var(--color-status-error)]">
-                  @for (error of result()!.errors; track error.row) {
+                  @for (error of result()!.errors; track $index) {
                     <li>{{ 'IMPORT.ROW' | translate }} {{ error.row }}: {{ error.message }}</li>
                   }
                 </ul>

--- a/src/app/components/inventory/inventory-list/inventory-list.ts
+++ b/src/app/components/inventory/inventory-list/inventory-list.ts
@@ -328,11 +328,17 @@ export class InventoryList implements OnInit {
 
   // Open import dialog
   openImportDialog(): void {
-    this.dialog.open(ImportDialog, {
+    const dialogRef = this.dialog.open(ImportDialog, {
       width: '800px',
       maxWidth: '95vw',
       disableClose: true,
       panelClass: 'import-dialog-container'
+    });
+
+    dialogRef.afterClosed().subscribe(imported => {
+      if (imported) {
+        this.inventoryService.refresh();
+      }
     });
   }
 

--- a/src/app/services/import.service.ts
+++ b/src/app/services/import.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { map, catchError, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 import { ImportResult } from '../interfaces/import.interface';
 import { environment } from '../../environments/environment';
 
@@ -27,8 +27,10 @@ export class ImportService {
         const link = document.createElement('a');
         link.href = url;
         link.download = 'plantilla-importacion.xlsx';
+        document.body.appendChild(link);
         link.click();
-        URL.revokeObjectURL(url);
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 100);
       }),
       map(() => void 0)
     );
@@ -56,8 +58,7 @@ export class ImportService {
             message: e.error
           }))
         };
-      }),
-      catchError(err => throwError(() => err))
+      })
     );
   }
 }

--- a/src/app/services/import.service.ts
+++ b/src/app/services/import.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, inject, signal } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { map, catchError } from 'rxjs/operators';
+import { map, catchError, tap } from 'rxjs/operators';
 import { ImportResult } from '../interfaces/import.interface';
 import { environment } from '../../environments/environment';
 
@@ -18,37 +18,31 @@ export class ImportService {
   private http = inject(HttpClient);
   private apiUrl = environment.apiUrl;
 
-  importing = signal(false);
-  progress = signal(0);
-
-  downloadTemplate(): void {
-    this.http.get(`${this.apiUrl}/inventory/import-template`, {
+  downloadTemplate(): Observable<void> {
+    return this.http.get(`${this.apiUrl}/inventory/import-template`, {
       responseType: 'blob'
-    }).subscribe(blob => {
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = 'plantilla-importacion.xlsx';
-      link.click();
-      URL.revokeObjectURL(url);
-    });
+    }).pipe(
+      tap(blob => {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'plantilla-importacion.xlsx';
+        link.click();
+        URL.revokeObjectURL(url);
+      }),
+      map(() => void 0)
+    );
   }
 
   uploadExcel(file: File): Observable<ImportResult> {
     const formData = new FormData();
     formData.append('file', file);
 
-    this.importing.set(true);
-    this.progress.set(50);
-
     return this.http.post<BulkOperationResult>(
       `${this.apiUrl}/inventory/bulk-import/excel`,
       formData
     ).pipe(
       map(result => {
-        this.importing.set(false);
-        this.progress.set(100);
-
         const total = result.success + result.failed;
         return {
           success: result.failed === 0,
@@ -61,13 +55,9 @@ export class ImportService {
             field: '',
             message: e.error
           }))
-        } as ImportResult;
+        };
       }),
-      catchError(err => {
-        this.importing.set(false);
-        this.progress.set(0);
-        return throwError(() => err);
-      })
+      catchError(err => throwError(() => err))
     );
   }
 }

--- a/src/app/services/import.service.ts
+++ b/src/app/services/import.service.ts
@@ -1,365 +1,73 @@
 import { Injectable, inject, signal } from '@angular/core';
-import { Observable, of, forkJoin } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
-import {
-  ImportRow,
-  ImportResult,
-  ImportPreview,
-  IMPORT_TEMPLATE_HEADERS
-} from '../interfaces/import.interface';
-import {
-  ItemType,
-  Currency,
-  InventoryStatus,
-  CreateInventoryItemDto
-} from '../interfaces/inventory-item.interface';
-import { InventoryService } from './inventory/inventory.service';
+import { ImportResult } from '../interfaces/import.interface';
+import { environment } from '../../environments/environment';
+
+interface BulkOperationResult {
+  success: number;
+  failed: number;
+  errors: Array<{ index?: number; id?: string; error: string }>;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class ImportService {
-  private inventoryService = inject(InventoryService);
+  private http = inject(HttpClient);
+  private apiUrl = environment.apiUrl;
 
   importing = signal(false);
   progress = signal(0);
 
-  /**
-   * Parse CSV content and return preview with validation
-   */
-  parseCSV(content: string): ImportPreview {
-    // Strip UTF-8 BOM and normalize line endings
-    content = content.replace(/^\uFEFF/, '').replace(/\r/g, '');
-    let lines = content.split('\n').filter(line => line.trim());
-
-    // Skip Excel separator hint line (e.g. "sep=;")
-    if (lines.length > 0 && /^sep=.$/i.test(lines[0].trim())) {
-      lines = lines.slice(1);
-    }
-
-    if (lines.length < 2) {
-      return { rows: [], validCount: 0, invalidCount: 0, totalCount: 0 };
-    }
-
-    // Detect delimiter (semicolon or comma)
-    const headerLine = lines[0];
-    const delimiter = headerLine.includes(';') ? ';' : ',';
-
-    // Normalize headers: strip *, remove spaces, lowercase (e.g. "Min Quantity*" → "minquantity")
-    const headers = this.parseCSVLine(headerLine, delimiter).map(h =>
-      h.replace(/\*/g, '').replace(/\s+/g, '').toLowerCase().trim()
-    );
-    const rows: ImportRow[] = [];
-
-    for (let i = 1; i < lines.length; i++) {
-      const values = this.parseCSVLine(lines[i], delimiter);
-      if (values.length === 0 || values.every(v => !v.trim())) continue;
-
-      const row = this.mapRowToImport(headers, values, i + 1);
-      rows.push(row);
-    }
-
-    const validCount = rows.filter(r => r.isValid).length;
-    const invalidCount = rows.filter(r => !r.isValid).length;
-
-    return {
-      rows,
-      validCount,
-      invalidCount,
-      totalCount: rows.length
-    };
-  }
-
-  /**
-   * Parse a single CSV line handling quoted values
-   */
-  private parseCSVLine(line: string, delimiter: string): string[] {
-    const result: string[] = [];
-    let current = '';
-    let inQuotes = false;
-
-    for (let i = 0; i < line.length; i++) {
-      const char = line[i];
-
-      if (char === '"') {
-        if (inQuotes && line[i + 1] === '"') {
-          current += '"';
-          i++;
-        } else {
-          inQuotes = !inQuotes;
-        }
-      } else if (char === delimiter && !inQuotes) {
-        result.push(current.trim());
-        current = '';
-      } else {
-        current += char;
-      }
-    }
-    result.push(current.trim());
-
-    return result;
-  }
-
-  /**
-   * Map CSV row values to ImportRow object with validation
-   */
-  private mapRowToImport(headers: string[], values: string[], rowNumber: number): ImportRow {
-    const getValue = (key: string): string => {
-      const index = headers.indexOf(key.toLowerCase());
-      return index >= 0 && values[index] ? values[index].trim() : '';
-    };
-
-    const errors: string[] = [];
-
-    // Required fields
-    const name = getValue('name');
-    if (!name) errors.push('Name is required');
-
-    const quantityStr = getValue('quantity');
-    const quantity = parseInt(quantityStr) || 0;
-    if (!quantityStr) errors.push('Quantity is required');
-
-    const category = getValue('category');
-    if (!category) errors.push('Category is required');
-
-    const warehouseName = getValue('warehousename') || getValue('warehouse');
-    if (!warehouseName) errors.push('Warehouse is required');
-
-    // Item type validation
-    const itemTypeStr = (getValue('itemtype') || getValue('type') || 'BULK').toUpperCase();
-    let itemType: ItemType;
-    if (itemTypeStr === 'UNIQUE') {
-      itemType = ItemType.UNIQUE;
-    } else {
-      itemType = ItemType.BULK;
-    }
-
-    // For UNIQUE items, serviceTag or serialNumber should be present
-    const serviceTag = getValue('servicetag');
-    const serialNumber = getValue('serialnumber');
-    if (itemType === ItemType.UNIQUE && !serviceTag && !serialNumber) {
-      errors.push('UNIQUE items require Service Tag or Serial Number');
-    }
-
-    // Currency validation
-    const currencyStr = (getValue('currency') || 'USD').toUpperCase();
-    let currency: Currency;
-    if (currencyStr === 'HNL') {
-      currency = Currency.HNL;
-    } else {
-      currency = Currency.USD;
-    }
-
-    // Price
-    const priceStr = getValue('price');
-    const price = priceStr ? parseFloat(priceStr.replace(',', '.')) : undefined;
-
-    // Min quantity
-    const minQuantityStr = getValue('minquantity') || getValue('min_quantity') || getValue('minqty');
-    const minQuantity = parseInt(minQuantityStr) || 0;
-
-    return {
-      rowNumber,
-      name,
-      description: getValue('description'),
-      quantity,
-      minQuantity,
-      category,
-      model: getValue('model'),
-      itemType,
-      serviceTag,
-      serialNumber,
-      sku: getValue('sku'),
-      barcode: getValue('barcode'),
-      price,
-      currency,
-      warehouseName,
-      supplierName: getValue('suppliername') || getValue('supplier'),
-      isValid: errors.length === 0,
-      errors
-    };
-  }
-
-  /**
-   * Validate rows against existing data (warehouses, suppliers)
-   */
-  validateAgainstData(rows: ImportRow[]): ImportRow[] {
-    const warehouses = this.inventoryService.warehouses();
-    const suppliers = this.inventoryService.suppliers();
-    const warehouseNames = new Map(warehouses.map(w => [w.name.toLowerCase(), w]));
-    const supplierNames = new Map(suppliers.map(s => [s.name.toLowerCase(), s]));
-
-    return rows.map(row => {
-      const newErrors = [...row.errors];
-
-      // Validate warehouse exists
-      if (row.warehouseName && !warehouseNames.has(row.warehouseName.toLowerCase())) {
-        newErrors.push(`Warehouse "${row.warehouseName}" not found`);
-      }
-
-      // Validate supplier if provided
-      if (row.supplierName && !supplierNames.has(row.supplierName.toLowerCase())) {
-        newErrors.push(`Supplier "${row.supplierName}" not found`);
-      }
-
-      return {
-        ...row,
-        errors: newErrors,
-        isValid: newErrors.length === 0
-      };
+  downloadTemplate(): void {
+    this.http.get(`${this.apiUrl}/inventory/import-template`, {
+      responseType: 'blob'
+    }).subscribe(blob => {
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'plantilla-importacion.xlsx';
+      link.click();
+      URL.revokeObjectURL(url);
     });
   }
 
-  /**
-   * Import valid rows to inventory
-   */
-  importRows(rows: ImportRow[]): Observable<ImportResult> {
-    const validRows = rows.filter(r => r.isValid);
-
-    if (validRows.length === 0) {
-      return of({
-        success: false,
-        totalRows: rows.length,
-        validRows: 0,
-        invalidRows: rows.length,
-        importedCount: 0,
-        errors: rows.flatMap(r => r.errors.map(e => ({
-          row: r.rowNumber,
-          field: '',
-          message: e
-        })))
-      });
-    }
+  uploadExcel(file: File): Observable<ImportResult> {
+    const formData = new FormData();
+    formData.append('file', file);
 
     this.importing.set(true);
-    this.progress.set(0);
+    this.progress.set(50);
 
-    const warehouses = this.inventoryService.warehouses();
-    const suppliers = this.inventoryService.suppliers();
-    const warehouseMap = new Map(warehouses.map(w => [w.name.toLowerCase(), w.id]));
-    const supplierMap = new Map(suppliers.map(s => [s.name.toLowerCase(), s.id]));
-
-    // Create items one by one
-    const createObservables = validRows.map((row, index) => {
-      const dto: CreateInventoryItemDto = {
-        name: row.name,
-        description: row.description,
-        quantity: row.quantity,
-        minQuantity: row.minQuantity,
-        category: row.category,
-        model: row.model,
-        itemType: row.itemType,
-        serviceTag: row.serviceTag,
-        serialNumber: row.serialNumber,
-        sku: row.sku,
-        barcode: row.barcode,
-        price: row.price,
-        currency: row.currency,
-        warehouseId: warehouseMap.get(row.warehouseName.toLowerCase()) || '',
-        supplierId: row.supplierName ? supplierMap.get(row.supplierName.toLowerCase()) : undefined
-      };
-
-      return this.inventoryService.createItem(dto).pipe(
-        map(item => {
-          this.progress.set(Math.round(((index + 1) / validRows.length) * 100));
-          return { success: true, row: row.rowNumber, item };
-        }),
-        catchError(err => of({
-          success: false,
-          row: row.rowNumber,
-          error: err.message || 'Failed to create item'
-        }))
-      );
-    });
-
-    return forkJoin(createObservables).pipe(
-      map(results => {
-        const imported = results.filter(r => r.success).length;
-        const errors = results
-          .filter(r => !r.success)
-          .map(r => ({
-            row: r.row,
-            field: '',
-            message: (r as any).error || 'Unknown error'
-          }));
-
-        // Audit logging is handled by the backend
+    return this.http.post<BulkOperationResult>(
+      `${this.apiUrl}/inventory/bulk-import/excel`,
+      formData
+    ).pipe(
+      map(result => {
         this.importing.set(false);
         this.progress.set(100);
 
+        const total = result.success + result.failed;
         return {
-          success: errors.length === 0,
-          totalRows: rows.length,
-          validRows: validRows.length,
-          invalidRows: rows.length - validRows.length,
-          importedCount: imported,
-          errors: [
-            ...rows.filter(r => !r.isValid).flatMap(r => r.errors.map(e => ({
-              row: r.rowNumber,
-              field: '',
-              message: e
-            }))),
-            ...errors
-          ]
-        };
+          success: result.failed === 0,
+          totalRows: total,
+          validRows: result.success,
+          invalidRows: result.failed,
+          importedCount: result.success,
+          errors: result.errors.map(e => ({
+            row: (e.index ?? -1) + 2, // +2: skip header row, convert 0-based index
+            field: '',
+            message: e.error
+          }))
+        } as ImportResult;
+      }),
+      catchError(err => {
+        this.importing.set(false);
+        this.progress.set(0);
+        return throwError(() => err);
       })
     );
-  }
-
-  /**
-   * Generate CSV template for download
-   */
-  generateTemplate(): string {
-    const headers = IMPORT_TEMPLATE_HEADERS.join(';');
-    const exampleRow = [
-      'Laptop Dell Latitude 5430',
-      'Business laptop 14 inch',
-      '1',
-      '1',
-      'Electronics',
-      'Latitude 5430',
-      'UNIQUE',
-      'ABC123',
-      'SN-456789',
-      'LAP-DELL-001',
-      '',
-      '1200.00',
-      'USD',
-      'Main Warehouse',
-      'Dell Inc'
-    ].join(';');
-
-    const bulkExample = [
-      'Paper A4 500 Sheets',
-      'White paper for printing',
-      '100',
-      '20',
-      'Office Supplies',
-      '',
-      'BULK',
-      '',
-      '',
-      'PAP-A4-500',
-      '123456789',
-      '5.99',
-      'USD',
-      'Main Warehouse',
-      ''
-    ].join(';');
-
-    return `sep=;\n${headers}\n${exampleRow}\n${bulkExample}`;
-  }
-
-  /**
-   * Download template as CSV file
-   */
-  downloadTemplate(): void {
-    const content = this.generateTemplate();
-    const BOM = '\uFEFF';
-    const blob = new Blob([BOM + content], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
-    link.href = URL.createObjectURL(blob);
-    link.download = 'inventory-import-template.csv';
-    link.click();
   }
 }

--- a/src/app/services/import.service.ts
+++ b/src/app/services/import.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
@@ -17,6 +18,7 @@ interface BulkOperationResult {
 export class ImportService {
   private http = inject(HttpClient);
   private apiUrl = environment.apiUrl;
+  private document = inject(DOCUMENT);
 
   downloadTemplate(): Observable<void> {
     return this.http.get(`${this.apiUrl}/inventory/import-template`, {
@@ -24,12 +26,12 @@ export class ImportService {
     }).pipe(
       tap(blob => {
         const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
+        const link = this.document.createElement('a');
         link.href = url;
         link.download = 'plantilla-importacion.xlsx';
-        document.body.appendChild(link);
+        this.document.body.appendChild(link);
         link.click();
-        document.body.removeChild(link);
+        this.document.body.removeChild(link);
         setTimeout(() => URL.revokeObjectURL(url), 100);
       }),
       map(() => void 0)

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -79,14 +79,14 @@
   },
   "IMPORT": {
     "TITLE": "Import Items",
-    "SUBTITLE": "Upload multiple items from a CSV file",
+    "SUBTITLE": "Upload multiple items from an Excel file",
     "TEMPLATE_INFO": "Download the template to see the correct format",
     "TEMPLATE_DESC": "The template includes examples of BULK and UNIQUE items with all available fields.",
-    "DOWNLOAD_TEMPLATE": "Download CSV Template",
+    "DOWNLOAD_TEMPLATE": "Download Excel Template",
     "DROP_FILE": "Drag and drop your file here",
     "OR": "or",
     "SELECT_FILE": "Select File",
-    "SUPPORTED_FORMATS": "Supported format: CSV (.csv)",
+    "SUPPORTED_FORMATS": "Supported format: Excel (.xlsx)",
     "TOTAL_ROWS": "Total Rows",
     "VALID_ROWS": "Valid Rows",
     "INVALID_ROWS": "Invalid Rows",
@@ -104,7 +104,11 @@
     "ERRORS": "Errors",
     "ERROR_DETAILS": "Error details",
     "ROW": "Row",
-    "IMPORT_VALID": "Import Valid"
+    "IMPORT_VALID": "Import Valid",
+    "INVALID_FORMAT": "Invalid format. Please upload an Excel file (.xlsx).",
+    "FILE_TOO_LARGE": "File is too large. Maximum size is 10MB.",
+    "GENERIC_ERROR": "Error importing the file. Please try again.",
+    "TRY_AGAIN": "Try Again"
   },
   "DASHBOARD": {
     "TITLE": "Inventory Management",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -79,14 +79,14 @@
   },
   "IMPORT": {
     "TITLE": "Importar Items",
-    "SUBTITLE": "Cargar múltiples items desde un archivo CSV",
+    "SUBTITLE": "Cargar múltiples items desde un archivo Excel",
     "TEMPLATE_INFO": "Descarga la plantilla para conocer el formato correcto",
     "TEMPLATE_DESC": "La plantilla incluye ejemplos de items BULK y UNIQUE con todos los campos disponibles.",
-    "DOWNLOAD_TEMPLATE": "Descargar Plantilla CSV",
+    "DOWNLOAD_TEMPLATE": "Descargar Plantilla Excel",
     "DROP_FILE": "Arrastra y suelta tu archivo aquí",
     "OR": "o",
     "SELECT_FILE": "Seleccionar Archivo",
-    "SUPPORTED_FORMATS": "Formato soportado: CSV (.csv)",
+    "SUPPORTED_FORMATS": "Formato soportado: Excel (.xlsx)",
     "TOTAL_ROWS": "Total Filas",
     "VALID_ROWS": "Filas Válidas",
     "INVALID_ROWS": "Filas Inválidas",
@@ -104,7 +104,11 @@
     "ERRORS": "Errores",
     "ERROR_DETAILS": "Detalle de errores",
     "ROW": "Fila",
-    "IMPORT_VALID": "Importar Válidos"
+    "IMPORT_VALID": "Importar Válidos",
+    "INVALID_FORMAT": "Formato inválido. Por favor sube un archivo Excel (.xlsx).",
+    "FILE_TOO_LARGE": "El archivo es demasiado grande. El tamaño máximo es 10MB.",
+    "GENERIC_ERROR": "Error al importar el archivo. Por favor intenta de nuevo.",
+    "TRY_AGAIN": "Intentar de Nuevo"
   },
   "DASHBOARD": {
     "TITLE": "Gestión de Inventario",


### PR DESCRIPTION
Switch from client-side CSV parsing + preview step to direct .xlsx upload via POST /inventory/bulk-import/excel. Removes preview step and local validation logic; backend now handles all processing and error reporting.