### PR TITLE
fix(outflows): restore modal a11y + reactive chart theme

### DIFF
--- a/src/app/components/outflows/outflow-form-dialog.ts
+++ b/src/app/components/outflows/outflow-form-dialog.ts
@@ -1,13 +1,18 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
+  HostListener,
   inject,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { A11yModule } from '@angular/cdk/a11y';
 import { LucideAngularModule } from 'lucide-angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
@@ -42,15 +47,19 @@ const REASONS: OutflowReason[] = [
 @Component({
   selector: 'app-outflow-form-dialog',
   standalone: true,
-  imports: [CommonModule, FormsModule, LucideAngularModule, TranslateModule],
+  imports: [CommonModule, FormsModule, A11yModule, LucideAngularModule, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" (click)="close()">
       <div
+        #dialogEl
         role="dialog"
         aria-modal="true"
         aria-labelledby="outflow-form-dialog-title"
-        class="bg-surface-variant border border-theme rounded-xl w-full max-w-lg max-h-[90vh] overflow-y-auto"
+        tabindex="-1"
+        cdkTrapFocus
+        cdkTrapFocusAutoCapture
+        class="bg-surface-variant border border-theme rounded-xl w-full max-w-lg max-h-[90vh] overflow-y-auto focus:outline-none"
         (click)="$event.stopPropagation()"
       >
         <div class="px-6 py-4 border-b border-theme">
@@ -221,15 +230,28 @@ const REASONS: OutflowReason[] = [
     </div>
   `,
 })
-export class OutflowFormDialog {
+export class OutflowFormDialog implements AfterViewInit {
   private outflowService = inject(OutflowService);
   private warehouseService = inject(WarehouseService);
   private inventoryService = inject(InventoryService);
   private notifications = inject(NotificationService);
   private translate = inject(TranslateService);
 
+  private dialogEl = viewChild<ElementRef<HTMLElement>>('dialogEl');
+
   closed = output<void>();
   created = output<OutflowFormResult>();
+
+  ngAfterViewInit(): void {
+    // cdkTrapFocusAutoCapture handles initial focus, but ensure the dialog
+    // container itself absorbs focus if nothing inside it is focusable yet.
+    queueMicrotask(() => this.dialogEl()?.nativeElement.focus());
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.close();
+  }
 
   readonly reasons = REASONS;
 

--- a/src/app/components/reports/reports.ts
+++ b/src/app/components/reports/reports.ts
@@ -13,6 +13,7 @@ import { InventoryService } from '../../services/inventory/inventory.service';
 import { TransactionService } from '../../services/transaction.service';
 import { UserService } from '../../services/user.service';
 import { PdfExportService } from '../../services/pdf-export.service';
+import { ThemeService } from '../../services/theme.service';
 import { triggerBlobDownload } from '../../utils/download.utils';
 import { InventoryItemInterface, InventoryStatus, ItemType } from '../../interfaces/inventory-item.interface';
 import { Transaction, TransactionType } from '../../interfaces/transaction.interface';
@@ -67,6 +68,7 @@ export class Reports implements OnInit {
   private userService = inject(UserService);
   private translate = inject(TranslateService);
   private pdfExportService = inject(PdfExportService);
+  private themeService = inject(ThemeService);
   private http = inject(HttpClient);
 
   // Tab state
@@ -325,7 +327,7 @@ export class Reports implements OnInit {
 
   trendChartOptions = computed(() => {
     const trends = this.transactionTrends();
-    const isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+    const isDark = this.themeService.isDark();
 
     return {
       series: [


### PR DESCRIPTION
- Outflow form dialog: cdkTrapFocus + auto-capture + Escape handler.
- Initial focus lands inside the dialog instead of the page behind it.
- reports.ts trend chart now subscribes to ThemeService.isDark() signal instead of reading data-theme off the DOM at template evaluation — flipping themes updates the chart immediately and survives SSR.